### PR TITLE
Add batch processing with error collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@types/rimraf": "^2.0.2",
+    "bottleneck": "^1.16.0",
     "github": "^11.0.0",
     "rimraf": "^2.6.2"
   },

--- a/src/github.ts
+++ b/src/github.ts
@@ -12,7 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as GitHub from 'github';
+import * as GitHubApi from 'github';
+import {batchProcess, concurrencyPresets} from './util/batch-process';
 
 /**
  * A reference to a GitHub repo, with an optional reference to a specific ref
@@ -134,11 +135,11 @@ function createGithubRepoReferenceFromPattern(pattern: string):
  */
 export class GitHubConnection {
   private _cache: Map<string, GitHubRepoData>;
-  private _github: GitHub;
+  private _github: GitHubApi;
 
   constructor(token: string) {
     this.resetCache();
-    this._github = new GitHub({protocol: 'https'});
+    this._github = new GitHubApi({protocol: 'https'});
     this._github.authenticate({type: 'oauth', token: token});
   }
 
@@ -262,47 +263,41 @@ export class GitHubConnection {
       return allGitHubRepos;
     }
 
-    await Promise.all([...ownersToLookup].map((pattern): Promise<void> => {
-      return (async () => {
-        const owner = pattern.substring(0, pattern.indexOf('/')).toLowerCase();
-        const namePattern =
-            pattern.substring(0, pattern.indexOf('*')).toLowerCase();
-        const ref = pattern.includes('#') &&
-            pattern.substring(pattern.indexOf('#') + 1);
-        const allOwnerRepos = await this.getOwnerRepos(owner);
-        // Filter all of this owner's repos for possible matches:
-        for (const possibleMatch of allOwnerRepos) {
-          // If the repo's fullName doesn't match the pattern prefix, ignore it.
-          if (!possibleMatch.fullName.toLowerCase().startsWith(namePattern)) {
-            continue;
-          }
-          // If a branch was defined after the wildcard but this repo doesn't
-          // have a ref with that name, ignore it.
-          if (ref && ref !== possibleMatch.defaultBranch) {
-            try {
-              const response = await this._github.gitdata.getReference({
-                owner: possibleMatch.owner,
-                repo: possibleMatch.name,
-                ref: 'heads/' + ref,
-              });
-              // GitHub API peculiarity: if ref isn't an exact match, GitHub
-              // switches behavior and returns all references that have `ref` as
-              // a prefix. Since we only want exact matches, add an extra check
-              // that the API did not return an array.
-              if (!isSuccessResponse(response) ||
-                  Array.isArray(response.data)) {
-                continue;
-              }
-            } catch (err) {
-              continue;
-            }
-          }
-          // Otherwise, it's a match! Add it to allGitHubRepos to be returned.
-          allGitHubRepos.push(createGitHubRepoReferenceFromDataAndReference(
-              possibleMatch, ref || possibleMatch.defaultBranch));
+    for (const pattern of ownersToLookup) {
+      const namePattern =
+          pattern.substring(0, pattern.indexOf('*')).toLowerCase();
+      const ref =
+          pattern.includes('#') && pattern.substring(pattern.indexOf('#') + 1);
+      const owner = pattern.substring(0, pattern.indexOf('/')).toLowerCase();
+      const allOwnerRepos = await this.getOwnerRepos(owner);
+      // Filter all of this owner's repos for possible matches:
+      await batchProcess(allOwnerRepos, async (possibleMatch) => {
+        // If the repo's fullName doesn't match the pattern prefix, ignore it.
+        if (!possibleMatch.fullName.toLowerCase().startsWith(namePattern)) {
+          return;
         }
-      })();
-    }));
+        // If a branch was defined after the wildcard but this repo doesn't
+        // have a ref with that name, ignore it.
+        // TODO(fks) 10-16-2017: Report reference match failures?
+        if (ref && ref !== possibleMatch.defaultBranch) {
+          const response = await this._github.gitdata.getReference({
+            owner: possibleMatch.owner,
+            repo: possibleMatch.name,
+            ref: 'heads/' + ref,
+          });
+          // GitHub API peculiarity: if ref isn't an exact match, GitHub
+          // switches behavior and returns all references that have `ref` as
+          // a prefix. Since we only want exact matches, add an extra check
+          // that the API did not return an array.
+          if (!isSuccessResponse(response) || Array.isArray(response.data)) {
+            return;
+          }
+        }
+        // Otherwise, it's a match! Add it to allGitHubRepos to be returned.
+        allGitHubRepos.push(createGitHubRepoReferenceFromDataAndReference(
+            possibleMatch, ref || possibleMatch.defaultBranch));
+      }, {concurrency: concurrencyPresets.github});
+    }
 
     return allGitHubRepos;
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -13,7 +13,7 @@
  */
 
 import * as GitHubApi from 'github';
-import {batchProcess, concurrencyPresets} from './util/batch-process';
+import {batchProcess, githubConcurrencyPreset} from './util/batch-process';
 
 /**
  * A reference to a GitHub repo, with an optional reference to a specific ref
@@ -296,7 +296,7 @@ export class GitHubConnection {
         // Otherwise, it's a match! Add it to allGitHubRepos to be returned.
         allGitHubRepos.push(createGitHubRepoReferenceFromDataAndReference(
             possibleMatch, ref || possibleMatch.defaultBranch));
-      }, {concurrency: concurrencyPresets.github});
+      }, {concurrency: githubConcurrencyPreset});
     }
 
     return allGitHubRepos;

--- a/src/test/git_test.ts
+++ b/src/test/git_test.ts
@@ -39,7 +39,8 @@ suite('src/git', function() {
       fs.mkdirSync(emptyDir);
       const gitInitResult = await exec(gitDir, `git`, [`init`]);
       assert.equal(gitInitResult.stderr, '');
-      const gitCommitResult = await exec(gitDir, `git`, [`commit`, `--allow-empty`, `-m`, `"testing"`]);
+      const gitCommitResult = await exec(
+          gitDir, `git`, [`commit`, `--allow-empty`, `-m`, `"testing"`]);
       assert.equal(gitCommitResult.stderr, '');
     });
 
@@ -78,30 +79,27 @@ suite('src/git', function() {
 
     });
 
-    suite('gitRepo.createBranch()', async() => {
+    suite('gitRepo.createBranch()', async () => {
 
       test('creates a new branch in the git repo', async () => {
         const gitRepo = new GitRepo(gitDir);
         await gitRepo.createBranch('abcdefgh');
-        const getBranchNameResult = await exec(
-          gitDir, 'git', ['status']);
+        const getBranchNameResult = await exec(gitDir, 'git', ['status']);
         assert.include(getBranchNameResult.stdout, 'On branch abcdefgh');
       });
 
     });
 
-    suite('gitRepo.checkout()', async() => {
+    suite('gitRepo.checkout()', async () => {
 
       test('creates a new branch in the git repo', async () => {
         const gitRepo = new GitRepo(gitDir);
         await exec(gitDir, 'git', ['checkout', '-b', 'branch-1']);
         await exec(gitDir, 'git', ['checkout', '-b', 'branch-2']);
-        const getBranch2NameResult = await exec(
-          gitDir, 'git', ['status']);
+        const getBranch2NameResult = await exec(gitDir, 'git', ['status']);
         assert.include(getBranch2NameResult.stdout, 'On branch branch-2');
         await gitRepo.checkout('branch-1');
-        const getBranch1NameResult = await exec(
-          gitDir, 'git', ['status']);
+        const getBranch1NameResult = await exec(gitDir, 'git', ['status']);
         assert.include(getBranch1NameResult.stdout, 'On branch branch-1');
       });
 

--- a/src/test/git_test.ts
+++ b/src/test/git_test.ts
@@ -24,11 +24,9 @@ import exec from '../util/exec';
 const rimraf: (dir: string) => void = util.promisify(_rimraf);
 
 suite('src/git', function() {
-
   this.timeout(20 * 1000);
 
   suite('GitRepo', () => {
-
     const gitDir = path.join(__dirname, 'POLYMER_WORKSPACES_GIT_DIR');
     const emptyDir = path.join(__dirname, 'POLYMER_WORKSPACES_EMPTY_DIR');
     const doesNotExistDir =
@@ -50,7 +48,6 @@ suite('src/git', function() {
     });
 
     suite('gitRepo.isGit()', () => {
-
       test('returns false if current directory does not exist', async () => {
         const doesNotExistGitRepo = new GitRepo(doesNotExistDir);
         assert.isFalse(doesNotExistGitRepo.isGit());
@@ -65,33 +62,27 @@ suite('src/git', function() {
         const gitRepo = new GitRepo(gitDir);
         assert.isTrue(gitRepo.isGit());
       });
-
     });
 
     suite('gitRepo.getHeadSha()', () => {
-
       test('returns the head SHA for a given git repo', async () => {
         const gitRepo = new GitRepo(gitDir);
         const gitHeadSha = await gitRepo.getHeadSha();
         assert.isString(gitHeadSha);
         assert.isOk(gitHeadSha.length > 6);
       });
-
     });
 
     suite('gitRepo.createBranch()', async () => {
-
       test('creates a new branch in the git repo', async () => {
         const gitRepo = new GitRepo(gitDir);
         await gitRepo.createBranch('abcdefgh');
         const getBranchNameResult = await exec(gitDir, 'git', ['status']);
         assert.include(getBranchNameResult.stdout, 'On branch abcdefgh');
       });
-
     });
 
     suite('gitRepo.checkout()', async () => {
-
       test('creates a new branch in the git repo', async () => {
         const gitRepo = new GitRepo(gitDir);
         await exec(gitDir, 'git', ['checkout', '-b', 'branch-1']);
@@ -102,9 +93,6 @@ suite('src/git', function() {
         const getBranch1NameResult = await exec(gitDir, 'git', ['status']);
         assert.include(getBranch1NameResult.stdout, 'On branch branch-1');
       });
-
     });
-
-
   });
 });

--- a/src/test/github_test.ts
+++ b/src/test/github_test.ts
@@ -19,7 +19,6 @@ import {testApiToken} from './_util/mock-api';
 
 
 suite('src/github', () => {
-
   suiteSetup(() => {
     mockApi.setup();
   });
@@ -29,9 +28,7 @@ suite('src/github', () => {
   });
 
   suite('GitHubConnection', () => {
-
     suite('githubConnection.expandRepoPatterns()', () => {
-
       let githubConnection: GitHubConnection;
 
       setup(() => {
@@ -144,11 +141,9 @@ suite('src/github', () => {
                 ['polymerelements/iron-*#ABCDEFGH']),
             []);
       });
-
     });
 
     suite('githubConnection.getRepoInfo()', () => {
-
       test('returns full GitHubRepo object from a reference', async () => {
         const githubConnection = new GitHubConnection(testApiToken);
         const repo = await githubConnection.getRepoInfo(
@@ -193,8 +188,6 @@ suite('src/github', () => {
         const repoCached = githubConnection.getCached('polymer/polymer');
         assert.isDefined(repoCached);
       });
-
     });
-
   });
 });

--- a/src/test/npm_test.ts
+++ b/src/test/npm_test.ts
@@ -25,11 +25,9 @@ const rimraf: (dir: string) => void = promisify(_rimraf);
 
 
 suite('src/npm', function() {
-
   this.timeout(20 * 1000);
 
   suite('NpmPackage', () => {
-
     const npmDir = path.join(__dirname, 'POLYMER_WORKSPACES_NPM_DIR');
     const emptyDir = path.join(__dirname, 'POLYMER_WORKSPACES_EMPTY_NPM_DIR');
 
@@ -52,7 +50,6 @@ suite('src/npm', function() {
         });
 
     suite('gitRepo.getPackageManifest()', () => {
-
       test('returns the parsed package.json for the package', async () => {
         const npmPackage = new NpmPackage(npmDir);
         const packageManifest = await npmPackage.getPackageManifest();
@@ -73,7 +70,6 @@ suite('src/npm', function() {
           assert.equal(packageManifestError.code, 'ENOENT');
         }
       });
-
     });
 
     suite.skip(
@@ -82,6 +78,5 @@ suite('src/npm', function() {
             // TODO(fks) 10-12-2017: Add tests. Tests skipped due to the
             // complexity of the underlying npm command.
         });
-
   });
 });

--- a/src/test/util/bower_test.ts
+++ b/src/test/util/bower_test.ts
@@ -13,7 +13,6 @@
  */
 
 suite('src/util/bower', () => {
-
   suite.skip(
       'mergedBowerConfigsFromRepos()',
       () => {
@@ -21,5 +20,4 @@ suite('src/util/bower', () => {
           // from
           // original naive implementation.
       });
-
 });

--- a/src/test/util/exec_test.ts
+++ b/src/test/util/exec_test.ts
@@ -16,9 +16,7 @@ import {assert} from 'chai';
 import exec, {checkCommand} from '../../util/exec';
 
 suite('src/util/exec', () => {
-
   suite('exec()', () => {
-
     test('returns false if current directory does not exist', async () => {
       const testCwd = process.cwd();
       const result = await exec(testCwd, 'pwd');
@@ -30,11 +28,9 @@ suite('src/util/exec', () => {
       const result = await exec('', 'echo', [testOutput]);
       assert.deepEqual(result, {stdout: testOutput, stderr: ''});
     });
-
   });
 
   suite('checkCommand()', () => {
-
     test('returns true if command exists in shell path', async () => {
       assert.isTrue(
           await checkCommand('node'));  // must be true to be running this test
@@ -44,7 +40,5 @@ suite('src/util/exec', () => {
       assert.isFalse(
           await checkCommand('there-is-no-way-this-exists-ia23t4niaq23n'));
     });
-
   });
-
 });

--- a/src/test/util/fs_test.ts
+++ b/src/test/util/fs_test.ts
@@ -21,9 +21,7 @@ const knownFilePath = __filename;
 const knownDoesNotExistPath = path.join(__dirname, 'AI92J53002GKGNFIAWNF');
 
 suite('src/util/fs', () => {
-
   suite('existsSync()', () => {
-
     test('returns true if something exists at path', async () => {
       assert.isTrue(fsUtil.existsSync(knownDirectoryPath));
       assert.isTrue(fsUtil.existsSync(knownFilePath));
@@ -32,11 +30,9 @@ suite('src/util/fs', () => {
     test('returns false if directory does not exist', async () => {
       assert.isFalse(fsUtil.existsSync(knownDoesNotExistPath));
     });
-
   });
 
   suite('isDirSync()', () => {
-
     test('returns true if path is a directory', async () => {
       assert.isTrue(fsUtil.isDirSync(knownDirectoryPath));
     });
@@ -46,7 +42,5 @@ suite('src/util/fs', () => {
     test('returns false if nothing exists at path', async () => {
       assert.isFalse(fsUtil.isDirSync(knownDoesNotExistPath));
     });
-
   });
-
 });

--- a/src/test/workspace_test.ts
+++ b/src/test/workspace_test.ts
@@ -23,21 +23,6 @@
 //
 // TODO(fks) 09-22-2017: Write some good integration tests instead.
 
-
-/**
- * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at
- * http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at
- * http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at
- * http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at
- * http://polymer.github.io/PATENTS.txt
- */
-
 import {assert} from 'chai';
 import path = require('path');
 import {Workspace} from '../workspace';
@@ -52,9 +37,11 @@ suite('src/workspace', function() {
     suite('workspace.init()', () => {
 
       test('can be initialized with an empty set of patterns', async () => {
-        const workspace = new Workspace({token: testGitHubToken, dir: testWorkspaceDir});
-        const repos = await workspace.init({include: []});
-        assert.deepEqual(repos, []);
+        const workspace =
+            new Workspace({token: testGitHubToken, dir: testWorkspaceDir});
+        const {workspaceRepos, failures} = await workspace.init({include: []});
+        assert.deepEqual(workspaceRepos, []);
+        assert.deepEqual([...failures], []);
       });
 
     });
@@ -62,12 +49,14 @@ suite('src/workspace', function() {
     suite('workspace.isInitialized', () => {
 
       test('returns false before init has been run', async () => {
-        const workspace = new Workspace({token: testGitHubToken, dir: testWorkspaceDir});
+        const workspace =
+            new Workspace({token: testGitHubToken, dir: testWorkspaceDir});
         assert.isFalse(workspace.isInitialized);
       });
 
       test('returns true after init has been run', async () => {
-        const workspace = new Workspace({token: testGitHubToken, dir: testWorkspaceDir});
+        const workspace =
+            new Workspace({token: testGitHubToken, dir: testWorkspaceDir});
         await workspace.init({include: []});
         assert.isTrue(workspace.isInitialized);
       });

--- a/src/test/workspace_test.ts
+++ b/src/test/workspace_test.ts
@@ -31,11 +31,8 @@ const testGitHubToken = 'TEST_GITHUB_TOKEN';
 const testWorkspaceDir = path.join(__dirname, 'TEST_WORKSPACE_DIR');
 
 suite('src/workspace', function() {
-
   suite('Workspace', () => {
-
     suite('workspace.init()', () => {
-
       test('can be initialized with an empty set of patterns', async () => {
         const workspace =
             new Workspace({token: testGitHubToken, dir: testWorkspaceDir});
@@ -43,11 +40,9 @@ suite('src/workspace', function() {
         assert.deepEqual(workspaceRepos, []);
         assert.deepEqual([...failures], []);
       });
-
     });
 
     suite('workspace.isInitialized', () => {
-
       test('returns false before init has been run', async () => {
         const workspace =
             new Workspace({token: testGitHubToken, dir: testWorkspaceDir});
@@ -60,9 +55,6 @@ suite('src/workspace', function() {
         await workspace.init({include: []});
         assert.isTrue(workspace.isInitialized);
       });
-
     });
-
   });
-
 });

--- a/src/util/batch-process.ts
+++ b/src/util/batch-process.ts
@@ -15,19 +15,17 @@
 import Bottleneck from 'bottleneck';
 
 /** Concurrency presets based on some basic benchmarking & common-sense. */
-export const concurrencyPresets = {
-  npmPublish: 6,
-  fs: 10,
-  github: 16,
-};
+export const npmPublishConcurrencyPreset = 6;
+export const fsConcurrencyPreset = 6;
+export const githubConcurrencyPreset = 16;
 
 /**
  * When running a batch process, return two collections: one of successful runs
  * that completed without throwing an exception, and one where an exception
  * occurred.
  */
-export interface BatchProcessResponse<T> {
-  successes: Map<T, any>;
+export interface BatchProcessResponse<T, V> {
+  successes: Map<T, V>;
   failures: Map<T, Error>;
 }
 
@@ -36,9 +34,9 @@ export interface BatchProcessResponse<T> {
  * called with each item as an argument). Group the results by successes an
  * failures based on whether an exception was thrown by that function.
  */
-export async function batchProcess<T>(
-    items: T[], fn: (repo: T) => Promise<any>, options?: {concurrency: number}):
-    Promise<BatchProcessResponse<T>> {
+export async function batchProcess<T, V>(
+    items: T[], fn: (repo: T) => Promise<V>, options?: {concurrency: number}):
+    Promise<BatchProcessResponse<T, V>> {
   const concurrency = (options && options.concurrency) || 0;
   const rateLimitter = new Bottleneck(concurrency);
   const successRuns = new Map<T, any>();

--- a/src/util/batch-process.ts
+++ b/src/util/batch-process.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import Bottleneck from 'bottleneck';
+
+/** Concurrency presets based on some basic benchmarking & common-sense. */
+export const concurrencyPresets = {
+  npmPublish: 6,
+  fs: 10,
+  github: 16,
+};
+
+/**
+ * When running a batch process, return two collections: one of successful runs
+ * that completed without throwing an exception, and one where an exception
+ * occurred.
+ */
+export interface BatchProcessResponse<T> {
+  successes: Map<T, any>;
+  failures: Map<T, Error>;
+}
+
+/**
+ * Run some function of work over each item in an array (where the function is
+ * called with each item as an argument). Group the results by successes an
+ * failures based on whether an exception was thrown by that function.
+ */
+export async function batchProcess<T>(
+    items: T[], fn: (repo: T) => Promise<any>, options?: {concurrency: number}):
+    Promise<BatchProcessResponse<T>> {
+  const concurrency = (options && options.concurrency) || 0;
+  const rateLimitter = new Bottleneck(concurrency);
+  const successRuns = new Map<T, any>();
+  const failRuns = new Map<T, Error>();
+
+  await Promise.all(items.map((item) => {
+    return rateLimitter.schedule(fn, item).then(
+        (result: any) => {
+          successRuns.set(item, result);
+        },
+        (err: Error) => {
+          failRuns.set(item, err);
+        });
+  }));
+  return {successes: successRuns, failures: failRuns};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,6 +73,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+bottleneck@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-1.16.0.tgz#d6ce13808527afc80b69092f15606655e5b21f1a"
+
 brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"


### PR DESCRIPTION
- With some rough benchmarking, workspace generation time for `"PolymerElements/*#2.0-preview"` drops from 2-3min to <1min!
- Best practices for running batches of work across repos moved to `src/batch-process.ts`
- Errors are now collected for every batch process, so that an exception in a single repo doesn't blow an entire run.

Resolves #2, Resolves #12 