### PR TITLE
fix excludes filtering, add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Made `Workspace.determineGitHubRepos()` method public.
+- Fixed `excludes` pattern filtering bug.
 <!-- Add new, unreleased items here. -->
 
 ## v2.0.0 [12-18-2017]

--- a/src/test/workspace_test.ts
+++ b/src/test/workspace_test.ts
@@ -51,7 +51,7 @@ suite('src/workspace', function() {
       });
     });
 
-    suite('workspace.determineGitHubRepos()', () => {
+    suite('workspace._determineGitHubRepos()', () => {
       test(
           'succesfully determines repos for a set of patterns to match',
           async () => {
@@ -60,7 +60,7 @@ suite('src/workspace', function() {
               dir: testWorkspaceDir,
               match: ['PolymerElements/paper-*']
             });
-            const repos = await workspace.determineGitHubRepos();
+            const repos = await workspace._determineGitHubRepos();
             assert.deepEqual(repos.map((r) => r.fullName), [
               'PolymerElements/paper-appbar',
               'PolymerElements/paper-button'
@@ -76,7 +76,7 @@ suite('src/workspace', function() {
               match: ['PolymerElements/paper-*'],
               exclude: ['PolymerElements/paper-button']
             });
-            const repos = await workspace.determineGitHubRepos();
+            const repos = await workspace._determineGitHubRepos();
             assert.deepEqual(
                 repos.map((r) => r.fullName), ['PolymerElements/paper-appbar']);
           });

--- a/src/test/workspace_test.ts
+++ b/src/test/workspace_test.ts
@@ -26,20 +26,60 @@
 import {assert} from 'chai';
 import path = require('path');
 import {Workspace} from '../workspace';
+import * as mockApi from './_util/mock-api';
+import {testApiToken} from './_util/mock-api';
 
-const testGitHubToken = 'TEST_GITHUB_TOKEN';
 const testWorkspaceDir = path.join(__dirname, 'TEST_WORKSPACE_DIR');
 
 suite('src/workspace', function() {
   suite('Workspace', () => {
+    suiteSetup(() => {
+      mockApi.setup();
+    });
+
+    suiteTeardown(() => {
+      mockApi.teardown();
+    });
+
     suite('workspace.init()', () => {
       test('can be initialized with an empty set of patterns', async () => {
-        const workspace =
-            new Workspace({token: testGitHubToken, dir: testWorkspaceDir, match: []});
+        const workspace = new Workspace(
+            {token: testApiToken, dir: testWorkspaceDir, match: []});
         const {workspaceRepos, failures} = await workspace.init();
         assert.deepEqual(workspaceRepos, []);
         assert.deepEqual([...failures], []);
       });
+    });
+
+    suite('workspace.determineGitHubRepos()', () => {
+      test(
+          'succesfully determines repos for a set of patterns to match',
+          async () => {
+            const workspace = new Workspace({
+              token: testApiToken,
+              dir: testWorkspaceDir,
+              match: ['PolymerElements/paper-*']
+            });
+            const repos = await workspace.determineGitHubRepos();
+            assert.deepEqual(repos.map((r) => r.fullName), [
+              'PolymerElements/paper-appbar',
+              'PolymerElements/paper-button'
+            ]);
+          });
+
+      test(
+          'succesfully determines repos for sets of patterns to match and exclude',
+          async () => {
+            const workspace = new Workspace({
+              token: testApiToken,
+              dir: testWorkspaceDir,
+              match: ['PolymerElements/paper-*'],
+              exclude: ['PolymerElements/paper-button']
+            });
+            const repos = await workspace.determineGitHubRepos();
+            assert.deepEqual(
+                repos.map((r) => r.fullName), ['PolymerElements/paper-appbar']);
+          });
     });
   });
 });

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -130,7 +130,7 @@ export class Workspace {
     await validateEnvironment();
 
     // Fetch our repos from the given patterns.
-    const githubRepos = await this.determineGitHubRepos();
+    const githubRepos = await this._determineGitHubRepos();
     let workspaceRepos = githubRepos.map((r) => this._openWorkspaceRepo(r));
     const failedWorkspaceRepos = new Map<WorkspaceRepo, Error>();
 
@@ -165,7 +165,7 @@ export class Workspace {
    * wildcard-containing patterns as needed) to return full GitHub repo
    * information for all matched repos.
    */
-  async determineGitHubRepos(): Promise<GitHubRepo[]> {
+  async _determineGitHubRepos(): Promise<GitHubRepo[]> {
     const matchPatterns = this.options.match;
     const excludePatterns =
         (this.options.exclude ||
@@ -176,9 +176,10 @@ export class Workspace {
       return !excludePatterns.includes(ref.fullName.toLowerCase());
     });
     // Fetch the full repo information for each matched reference
-    const matchedRepos = await batchProcess(matchedReferences, async (ref) => {
-      return this._github.getRepoInfo(ref);
-    }, {concurrency: githubConcurrencyPreset});
+    const matchedRepos = await batchProcess(
+        matchedReferences,
+        async (ref) => this._github.getRepoInfo(ref),
+        {concurrency: githubConcurrencyPreset});
     matchedRepos.failures.forEach((err, ref) => {
       console.log(`Repo not found: ${ref.fullName} (${err.message})`);
     });

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -130,7 +130,7 @@ export class Workspace {
     await validateEnvironment();
 
     // Fetch our repos from the given patterns.
-    const githubRepos = await this._determineGitHubRepos();
+    const githubRepos = await this.determineGitHubRepos();
     let workspaceRepos = githubRepos.map((r) => this._openWorkspaceRepo(r));
     const failedWorkspaceRepos = new Map<WorkspaceRepo, Error>();
 
@@ -165,20 +165,20 @@ export class Workspace {
    * wildcard-containing patterns as needed) to return full GitHub repo
    * information for all matched repos.
    */
-  private async _determineGitHubRepos(): Promise<GitHubRepo[]> {
+  async determineGitHubRepos(): Promise<GitHubRepo[]> {
     const matchPatterns = this.options.match;
     const excludePatterns =
-        (this.options.exclude || []).map(String.prototype.toLowerCase);
+        (this.options.exclude ||
+         []).map(((excludePattern) => excludePattern.toLowerCase()));
     const allMatchedReferences =
         await this._github.expandRepoPatterns(matchPatterns);
     const matchedReferences = allMatchedReferences.filter((ref) => {
       return !excludePatterns.includes(ref.fullName.toLowerCase());
     });
     // Fetch the full repo information for each matched reference
-    const matchedRepos =
-        await batchProcess(matchedReferences, async (ref) => {
-          return this._github.getRepoInfo(ref);
-        }, {concurrency: githubConcurrencyPreset});
+    const matchedRepos = await batchProcess(matchedReferences, async (ref) => {
+      return this._github.getRepoInfo(ref);
+    }, {concurrency: githubConcurrencyPreset});
     matchedRepos.failures.forEach((err, ref) => {
       console.log(`Repo not found: ${ref.fullName} (${err.message})`);
     });


### PR DESCRIPTION
 - [X] CHANGELOG.md has been updated

This PR exposes a previously private method for testing purposes. I'm generally against doing this, but the alternative would mean to mock out the internal git clone logic. This seemed more reasonable, but I'm open to different solutions if this is a step to far for anyone.